### PR TITLE
Json handler expansions

### DIFF
--- a/include/ulib/json/value.h
+++ b/include/ulib/json/value.h
@@ -2401,7 +2401,7 @@ public:
 # if defined(HAVE_CXX17) && !defined(__clang__)
 #  include <unordered_map>
 
-PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(type) \
+ #define PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(type) \
                                                                                                                                \
    template <class T> class U_EXPORT UJsonTypeHandler<std::unordered_map<UString, #type> > : public UJsonTypeHandler_Base {    \
    public:                                                                                                                     \
@@ -2466,6 +2466,7 @@ PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(type) \
             }                                                                                                                  \
          }                                                                                                                     \
    };                                                                                                                          \
+	
 
 PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(int64_t)
 PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(uint64_t)

--- a/include/ulib/json/value.h
+++ b/include/ulib/json/value.h
@@ -2452,7 +2452,7 @@ public:
                                                                                                                                \
          while (pelement)                                                                                                      \
             {                                                                                                                  \
-            #type pitem;                                                                                                       \
+            type pitem;                                                                                                       \
                                                                                                                                \
             UJsonTypeHandler<type>(pitem).fromJSON(*pelement);                                                                \
                                                                                                                                \

--- a/include/ulib/json/value.h
+++ b/include/ulib/json/value.h
@@ -2401,9 +2401,9 @@ public:
 # if defined(HAVE_CXX17) && !defined(__clang__)
 #  include <unordered_map>
 
- #define PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(type) \
+ #define PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(type, template) \
                                                                                                                                \
-   template <class T> class U_EXPORT UJsonTypeHandler<std::unordered_map<UString, #type> > : public UJsonTypeHandler_Base {    \
+   template <#template> class U_EXPORT UJsonTypeHandler<std::unordered_map<UString, #type> > : public UJsonTypeHandler_Base {    \
    public:                                                                                                                     \
       typedef std::unordered_map<UString, #type> ustringmap;                                                                   \
                                                                                                                                \
@@ -2468,10 +2468,10 @@ public:
    };                                                                                                                          \
 	
 
-PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(int64_t)
-PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(uint64_t)
-PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(T)
-PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(T*)
+PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(int64_t, )
+PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(uint64_t, )
+PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(T, class T)
+PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(T*, class T)
 
 # endif
 #endif

--- a/include/ulib/json/value.h
+++ b/include/ulib/json/value.h
@@ -2401,9 +2401,9 @@ public:
 # if defined(HAVE_CXX17) && !defined(__clang__)
 #  include <unordered_map>
 
- #define PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(type, template) \
+ #define PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(type, templateParameter) \
                                                                                                                                \
-   template <template> class U_EXPORT UJsonTypeHandler<std::unordered_map<UString, type> > : public UJsonTypeHandler_Base {    \
+   template <templateParameter> class U_EXPORT UJsonTypeHandler<std::unordered_map<UString, type> > : public UJsonTypeHandler_Base {    \
    public:                                                                                                                     \
       typedef std::unordered_map<UString, type> ustringmap;                                                                   \
                                                                                                                                \

--- a/include/ulib/json/value.h
+++ b/include/ulib/json/value.h
@@ -2403,9 +2403,9 @@ public:
 
  #define PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(type, template) \
                                                                                                                                \
-   template <#template> class U_EXPORT UJsonTypeHandler<std::unordered_map<UString, #type> > : public UJsonTypeHandler_Base {    \
+   template <template> class U_EXPORT UJsonTypeHandler<std::unordered_map<UString, type> > : public UJsonTypeHandler_Base {    \
    public:                                                                                                                     \
-      typedef std::unordered_map<UString, #type> ustringmap;                                                                   \
+      typedef std::unordered_map<UString, type> ustringmap;                                                                   \
                                                                                                                                \
       explicit UJsonTypeHandler(ustringmap& map) : UJsonTypeHandler_Base(&map) {}                                              \
                                                                                                                                \
@@ -2434,7 +2434,7 @@ public:
             {                                                                                                                  \
             json.__push('{');                                                                                                  \
    			                                                                                                                   \
-            for (const auto & [ key, value ] : *pmap) json.toJSON<#type>(key, UJsonTypeHandler<#type>(value));                 \
+            for (const auto & [ key, value ] : *pmap) json.toJSON<type>(key, UJsonTypeHandler<type>(value));                 \
                                                                                                                                \
             json.setLastChar('}');                                                                                             \
             }                                                                                                                  \
@@ -2454,7 +2454,7 @@ public:
             {                                                                                                                  \
             #type pitem;                                                                                                       \
                                                                                                                                \
-            UJsonTypeHandler<#type>(pitem).fromJSON(*pelement);                                                                \
+            UJsonTypeHandler<type>(pitem).fromJSON(*pelement);                                                                \
                                                                                                                                \
             UStringRep* rep = (UStringRep*)u_getPayload(pelement->pkey.ival);                                                  \
                                                                                                                                \

--- a/include/ulib/json/value.h
+++ b/include/ulib/json/value.h
@@ -2401,24 +2401,24 @@ public:
 # if defined(HAVE_CXX17) && !defined(__clang__)
 #  include <unordered_map>
 
- #define PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(type, templateParameter) \
-                                                                                                                               \
-   template <templateParameter> class U_EXPORT UJsonTypeHandler<std::unordered_map<UString, type> > : public UJsonTypeHandler_Base {    \
+ #define PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(type, templateParameter, accessQualifier)                                              \
+                                                                                                                                                   \
+   template <templateParameter> class U_EXPORT UJsonTypeHandler<std::unordered_map<UString, type> > : public UJsonTypeHandler_Base {   \
    public:                                                                                                                     \
-      typedef std::unordered_map<UString, type> ustringmap;                                                                   \
+      typedef std::unordered_map<UString, type> ustringmap;                                                        \
                                                                                                                                \
       explicit UJsonTypeHandler(ustringmap& map) : UJsonTypeHandler_Base(&map) {}                                              \
                                                                                                                                \
       void clear()                                                                                                             \
          {                                                                                                                     \
-         U_TRACE_NO_PARAM(0, "\"UJsonTypeHandler<ustring" #type "map>::clear()\"")                                             \
+         U_TRACE_NO_PARAM(0, "UJsonTypeHandler<ustring" #type "map>::clear()")                                    \
                                                                                                                                \
          ((ustringmap*)pval)->clear();                                                                                         \
          }                                                                                                                     \
                                                                                                                                \
       void toJSON(UString& json)                                                                                               \
          {                                                                                                                     \
-         U_TRACE(0, "\"UJsonTypeHandler<ustring" #type "map>::toJSON(%p)\"", &json)                                            \
+         U_TRACE(0, "UJsonTypeHandler<ustring" #type "map>::toJSON(%p)", &json)                                   \
                                                                                                                                \
          ustringmap* pmap = (ustringmap*)pval;                                                                                 \
                                                                                                                                \
@@ -2434,7 +2434,7 @@ public:
             {                                                                                                                  \
             json.__push('{');                                                                                                  \
    			                                                                                                                   \
-            for (const auto & [ key, value ] : *pmap) json.toJSON<type>(key, UJsonTypeHandler<type>(value));                 \
+            for (auto & [ key, value ] : *pmap) json.toJSON<type>(key, UJsonTypeHandler<type>(value)); \
                                                                                                                                \
             json.setLastChar('}');                                                                                             \
             }                                                                                                                  \
@@ -2444,7 +2444,7 @@ public:
                                                                                                                                \
       void fromJSON(UValue& json)                                                                                              \
          {                                                                                                                     \
-         U_TRACE(0, "\"UJsonTypeHandler<ustring" #type "map>::fromJSON(%p)\"", &json)                                          \
+         U_TRACE(0, "UJsonTypeHandler<ustring" #type "map>::fromJSON(%p)", &json)                                 \
                                                                                                                                \
          U_ASSERT(((ustringmap*)pval)->empty())                                                                                \
                                                                                                                                \
@@ -2452,15 +2452,16 @@ public:
                                                                                                                                \
          while (pelement)                                                                                                      \
             {                                                                                                                  \
-            type pitem;                                                                                                       \
                                                                                                                                \
-            UJsonTypeHandler<type>(pitem).fromJSON(*pelement);                                                                \
+            type pitem;                                                                                                        \
                                                                                                                                \
-            UStringRep* rep = (UStringRep*)u_getPayload(pelement->pkey.ival);                                                  \
+            UJsonTypeHandler<type>(accessQualifier pitem).fromJSON(*pelement);                                                 \
                                                                                                                                \
-            U_INTERNAL_DUMP("pelement->pkey(%p) = %V", rep, rep)                                                               \
+            UString key = UString((UStringRep*)u_getPayload(pelement->pkey.ival));                                             \
                                                                                                                                \
-            ((ustringmap*)pval)->insert_or_assign(rep, pitem);                                                                 \
+            U_INTERNAL_DUMP("pelement->pkey(%p) = %V", key, key.rep)                                                           \
+                                                                                                                               \
+            ((ustringmap*)pval)->insert_or_assign(key, pitem);                                                                 \
                                                                                                                                \
             pelement = pelement->next;                                                                                         \
             }                                                                                                                  \
@@ -2468,10 +2469,15 @@ public:
    };                                                                                                                          \
 	
 
-PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(int64_t, )
-PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(uint64_t, )
-PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(T, class T)
-PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(T*, class T)
+#define yesPointer *
+#define noPointer  
+
+PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(int64_t, , noPointer)
+PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(uint64_t, , noPointer)
+PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(T, class T, noPointer)
+PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(T*, class T, yesPointer)
+#undef yesPointer
+#undef noPointer
 
 # endif
 #endif

--- a/include/ulib/json/value.h
+++ b/include/ulib/json/value.h
@@ -2401,70 +2401,77 @@ public:
 # if defined(HAVE_CXX17) && !defined(__clang__)
 #  include <unordered_map>
 
-template <class T> class U_EXPORT UJsonTypeHandler<std::unordered_map<UString, T> > : public UJsonTypeHandler_Base {
-public:
-   typedef std::unordered_map<UString, T> stringtobitmaskmap;
+PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(type) \
+                                                                                                                               \
+   template <class T> class U_EXPORT UJsonTypeHandler<std::unordered_map<UString, #type> > : public UJsonTypeHandler_Base {    \
+   public:                                                                                                                     \
+      typedef std::unordered_map<UString, #type> ustringmap;                                                                   \
+                                                                                                                               \
+      explicit UJsonTypeHandler(ustringmap& map) : UJsonTypeHandler_Base(&map) {}                                              \
+                                                                                                                               \
+      void clear()                                                                                                             \
+         {                                                                                                                     \
+         U_TRACE_NO_PARAM(0, "\"UJsonTypeHandler<ustring" #type "map>::clear()\"")                                             \
+                                                                                                                               \
+         ((ustringmap*)pval)->clear();                                                                                         \
+         }                                                                                                                     \
+                                                                                                                               \
+      void toJSON(UString& json)                                                                                               \
+         {                                                                                                                     \
+         U_TRACE(0, "\"UJsonTypeHandler<ustring" #type "map>::toJSON(%p)\"", &json)                                            \
+                                                                                                                               \
+         ustringmap* pmap = (ustringmap*)pval;                                                                                 \
+                                                                                                                               \
+         if (pmap->empty())                                                                                                    \
+            {                                                                                                                  \
+            char* ptr = json.pend();                                                                                           \
+                                                                                                                               \
+            u_put_unalignedp16(ptr, U_MULTICHAR_CONSTANT16('{','}'));                                                          \
+                                                                                                                               \
+            json.rep->_length += 2;                                                                                            \
+            }                                                                                                                  \
+         else                                                                                                                  \
+            {                                                                                                                  \
+            json.__push('{');                                                                                                  \
+   			                                                                                                                   \
+            for (const auto & [ key, value ] : *pmap) json.toJSON<#type>(key, UJsonTypeHandler<#type>(value));                 \
+                                                                                                                               \
+            json.setLastChar('}');                                                                                             \
+            }                                                                                                                  \
+                                                                                                                               \
+         U_INTERNAL_DUMP("json(%u) = %V", json.size(), json.rep)                                                               \
+         }                                                                                                                     \
+                                                                                                                               \
+      void fromJSON(UValue& json)                                                                                              \
+         {                                                                                                                     \
+         U_TRACE(0, "\"UJsonTypeHandler<ustring" #type "map>::fromJSON(%p)\"", &json)                                          \
+                                                                                                                               \
+         U_ASSERT(((ustringmap*)pval)->empty())                                                                                \
+                                                                                                                               \
+         UValue* pelement = json.toNode();                                                                                     \
+                                                                                                                               \
+         while (pelement)                                                                                                      \
+            {                                                                                                                  \
+            #type pitem;                                                                                                       \
+                                                                                                                               \
+            UJsonTypeHandler<#type>(pitem).fromJSON(*pelement);                                                                \
+                                                                                                                               \
+            UStringRep* rep = (UStringRep*)u_getPayload(pelement->pkey.ival);                                                  \
+                                                                                                                               \
+            U_INTERNAL_DUMP("pelement->pkey(%p) = %V", rep, rep)                                                               \
+                                                                                                                               \
+            ((ustringmap*)pval)->insert_or_assign(rep, pitem);                                                                 \
+                                                                                                                               \
+            pelement = pelement->next;                                                                                         \
+            }                                                                                                                  \
+         }                                                                                                                     \
+   };                                                                                                                          \
 
-   explicit UJsonTypeHandler(stringtobitmaskmap& map) : UJsonTypeHandler_Base(&map) {}
+PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(int64_t)
+PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(uint64_t)
+PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(T)
+PRINT_U_STRING_UNORDERED_MAP_JSON_HANDLER_FOR_TYPE(T*)
 
-   void clear()
-      {
-      U_TRACE_NO_PARAM(0, "UJsonTypeHandler<stringtobitmaskmap>::clear()")
-
-      ((stringtobitmaskmap*)pval)->clear();   
-      }
-
-   void toJSON(UString& json)
-      {
-      U_TRACE(0, "UJsonTypeHandler<stringtobitmaskmap>::toJSON(%V)", json.rep)
-
-      stringtobitmaskmap* pmap = (stringtobitmaskmap*)pval;
-
-      if (pmap->empty())
-         {
-         char* ptr = json.pend();
-
-         u_put_unalignedp16(ptr, U_MULTICHAR_CONSTANT16('{','}'));
-
-         json.rep->_length += 2;
-         }
-      else
-         {
-         json.__push('{');
-
-         // this is is C++17 vvv
-         for (const auto & [ key, value ] : *pmap) json.toJSON<T>(key, UJsonTypeHandler<T>(value)); 
-
-         json.setLastChar('}');
-         }
-
-      U_INTERNAL_DUMP("json(%u) = %V", json.size(), json.rep)
-      }
-
-   void fromJSON(UValue& json)
-      {
-      U_TRACE(0, "UJsonTypeHandler<stringtobitmaskmap>::fromJSON(%p)", &json)
-
-      U_ASSERT(((stringtobitmaskmap*)pval)->empty())
-
-      UValue* pelement = json.toNode();
-
-      while (pelement)
-         {
-         uint64_t pitem;
-
-         UJsonTypeHandler<uint64_t>(pitem).fromJSON(*pelement);
-
-         UStringRep* rep = (UStringRep*)u_getPayload(pelement->pkey.ival);
-
-         U_INTERNAL_DUMP("pelement->pkey(%p) = %V", rep, rep)
-
-         ((stringtobitmaskmap*)pval)->insert_or_assign(rep, pitem); // insert_or_assign is C++17 
-
-         pelement = pelement->next;
-         }
-      }
-};
 # endif
 #endif
 #endif


### PR DESCRIPTION
added a print macro to create JSONHandlers for std::unordered_map<UString, type> objects, plus executed it for types T, T*, uint64_t and int64_t