### PR TITLE
Update services.h

### DIFF
--- a/include/ulib/utility/services.h
+++ b/include/ulib/utility/services.h
@@ -176,7 +176,8 @@ struct U_EXPORT UServices {
       UString code(len);
       char* ptr = code.data();
 
-      for (uint32_t i = 0; i < len; ++i, ++ptr) *ptr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"[u_get_num_random(64 - 3)];
+      static const char *alphaNumeric = “ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789“;
+		for (uint32_t i = 0; i < len; ++i, ++ptr) *ptr = alphaNumeric[u_get_num_random(62) - 1]; 
 
       code.size_adjust(len);
 


### PR DESCRIPTION
in u_get_num_random, the +1 after modulus division, results in index 0 never being picked and shifts the potential range 1 out of bounds... easiest to just subtract 1 here