### PR TITLE
Cluster Client Changes

### DIFF
--- a/include/ulib/net/client/redis.h
+++ b/include/ulib/net/client/redis.h
@@ -985,7 +985,7 @@ class U_EXPORT UREDISClusterClient : public UREDISClient<UTCPSocket> {
 private:
 
    struct RedisNode {
-      UString ipAddress;
+      UString ipAddress, port;
       UREDISClient<UTCPSocket> client;
       uint16_t lowHashSlot, highHashSlot;
    };
@@ -1059,8 +1059,10 @@ public:
 
       UREDISClient<UTCPSocket>::connect(host, _port);
       calculateNodeMap();
-
-      subscriptionClient.connect(host, _port);
+		
+		// select random master node to be responsible for SUB/PUB traffic
+		const RedisNode& node = redisNodes[u_get_num_random_range0(redisNodes.size())];
+      subscriptionClient.connect(node.ipAddress, node.port);
    }
 
    const UVector<UString>& processPipeline(UString& pipeline, const bool silence, const bool reorderable);


### PR DESCRIPTION
Cluster Client Changes:

1) Correctly implements SUB/PUB activity on Cluster Client.

2) Allows reordering for anonMultis.

3) Correctly handles when the user has inserted CLIENT REPLY SKIP/OFF/ON type directives into the anon flows, and warns against using any other non-hash slot style keys (aka not xyz{abc}123 format keys) in the flow at this time.

