### PR TITLE
UCompileTimeString

### DIFF
--- a/include/ulib/string.h
+++ b/include/ulib/string.h
@@ -134,6 +134,25 @@ template <class T> class UJsonTypeHandler;
 typedef void (*vPFprpv)(UStringRep*,void*);
 typedef bool (*bPFprpv)(UStringRep*,void*);
 
+class UCompileTimeString {
+private:
+
+   const char * const string;
+   size_t length;
+
+public:
+
+   template<size_t N>
+   constexpr UCompileTimeString(const char(&literal)[N]) : string(literal), length(N - 1) {}
+
+   constexpr char operator[](size_t index) { return string[index]; }
+
+   // implicit cast to zero-terminated C-string
+   constexpr operator const char *() const { return string; }
+
+   constexpr size_t size() { return length; }
+};
+
 class U_EXPORT UStringRep {
 public:
 
@@ -2346,6 +2365,20 @@ public:
    static vpFpcu printValueToBuffer;
 
    void printKeyValue(const char* key, uint32_t keylen, const char* data, uint32_t datalen);
+	
+	void snprintf_ct(UCompileTimeString format, ...)
+      {
+      U_TRACE(0, "UString::snprintf_ct(%.*S,%u)", format.size(), format, format.size())
+
+      U_INTERNAL_ASSERT_POINTER(format)
+
+      va_list argp;
+      va_start(argp, format.size());
+
+      UString::vsnprintf(format, format.size(), argp); 
+
+      va_end(argp);
+      }
 
    void snprintf(const char* format, uint32_t fmt_size, ...)
       {

--- a/include/ulib/string.h
+++ b/include/ulib/string.h
@@ -2365,20 +2365,6 @@ public:
    static vpFpcu printValueToBuffer;
 
    void printKeyValue(const char* key, uint32_t keylen, const char* data, uint32_t datalen);
-	
-	void snprintf_ct(UCompileTimeString format, ...)
-      {
-      U_TRACE(0, "UString::snprintf_ct(%.*S,%u)", format.size(), format, format.size())
-
-      U_INTERNAL_ASSERT_POINTER(format)
-
-      va_list argp;
-      va_start(argp, format.size());
-
-      UString::vsnprintf(format, format.size(), argp); 
-
-      va_end(argp);
-      }
 
    void snprintf(const char* format, uint32_t fmt_size, ...)
       {
@@ -2393,6 +2379,12 @@ public:
 
       va_end(argp);
       }
+	
+	template<class...Args>
+   void snprintf_ct(UCompileTimeString format, Args&&...args)
+   {
+      snprintf(format, format.size(), std::forward<Args>(args)...);
+   }
 
    void snprintf_add(const char* format, uint32_t fmt_size, ...)
       {
@@ -2407,6 +2399,12 @@ public:
 
       va_end(argp);
       }
+	
+	template<class...Args>
+   void snprintf_add_ct(UCompileTimeString format, Args&&...args)
+   {
+      snprintf_add(format, format.size(), std::forward<Args>(args)...);
+   }
 
    void snprintf_pos(uint32_t pos, const char* format, uint32_t fmt_size, ...)
       {
@@ -2426,6 +2424,12 @@ public:
 
       va_end(argp);
       }
+	
+	template<class...Args>
+   void snprintf_pos_ct(uint32_t pos, UCompileTimeString format, Args&&...args)
+   {
+      snprintf_pos(format, format.size(), std::forward<Args>(args)...);
+   }
 
    void size_adjust()                      { rep->size_adjust(); }
    void size_adjust(uint32_t value)        { rep->size_adjust(value); }


### PR DESCRIPTION
now we get compile time string literals and compile time format strings!

there's lots we can do with this but I figured I'd start here.

i don't believe it's possible to both have UCompileTimeString implicitly convert to const char * AND keep the function signatures the same. So for now I appended them with "_ct" as in "compile time".

here's an example

```
#include <ulib/string.h>

int main (int argc, char* argv[], char* env[])
{
   U_ULIB_INIT(argv);

   UString workingString(300U);
   workingString.snprintf_ct("test %lu format with %s", 0, UCompileTimeString("ucompiletimestring"));

   U_WARNING("workingString = %v", workingString.rep);

   return EXIT_SUCCESS;
}
```